### PR TITLE
New Data Source: `azurepreview_resources`

### DIFF
--- a/azurepreview/config.go
+++ b/azurepreview/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-01-01/consumption"
 	"github.com/Azure/azure-sdk-for-go/services/preview/subscription/mgmt/2019-10-01-preview/subscription"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-11-01/subscriptions"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -23,6 +24,7 @@ type Config struct {
 
 type Meta struct {
 	Budgets       consumption.BudgetsClient
+	Resources     resources.Client
 	Subscription  subscription.Client
 	Subscriptions subscriptions.Client
 	StopContext   context.Context
@@ -40,6 +42,9 @@ func (c *Config) Client(userAgent string) (*Meta, diag.Diagnostics) {
 
 	meta.Budgets = consumption.NewBudgetsClient(c.SubscriptionID)
 	configureClient(&meta.Budgets.Client, userAgent, authorizer)
+
+	meta.Resources = resources.NewClient(c.SubscriptionID)
+	configureClient(&meta.Resources.Client, userAgent, authorizer)
 
 	meta.Subscription = subscription.NewClient()
 	configureClient(&meta.Subscription.Client, userAgent, authorizer)

--- a/azurepreview/data_source_resources.go
+++ b/azurepreview/data_source_resources.go
@@ -1,0 +1,166 @@
+package azurepreview
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAzurePreviewResources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAzurePreviewResourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"subscription_id": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: stringIsNotEmpty,
+			},
+
+			"name": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: stringIsNotEmpty,
+			},
+
+			"resource_group_name": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: stringIsNotEmpty,
+			},
+
+			"type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: stringIsNotEmpty,
+			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAzurePreviewResourcesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	client := meta.(*Meta).Resources
+
+	tags := d.Get("tags").(map[string]interface{})
+
+	if v, ok := d.GetOk("subscription_id"); ok {
+		client.SubscriptionID = v.(string)
+	}
+
+	var filters []string
+
+	if v, ok := d.GetOk("type"); ok {
+		filters = append(filters, fmt.Sprintf("resourceType eq '%s'", v.(string)))
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		filters = append(filters, fmt.Sprintf("name eq '%s'", v.(string)))
+	}
+
+	if v, ok := d.GetOk("resource_group_name"); ok {
+		filters = append(filters, fmt.Sprintf("resourceGroup eq '%s'", v.(string)))
+	}
+
+	filter := strings.Join(filters, " and ")
+
+	resp, err := client.ListComplete(ctx, filter, "", nil)
+	if err != nil {
+		return diag.Errorf("error reading resources: %+v", err)
+	}
+
+	resources := make([]map[string]interface{}, 0)
+
+	for resp.NotDone() {
+		resource := make(map[string]interface{})
+
+		value := resp.Value()
+
+		if v := value.ID; v != nil {
+			resource["id"] = *v
+		}
+
+		if v := value.Name; v != nil {
+			resource["name"] = *v
+		}
+
+		if v := value.Type; v != nil {
+			resource["type"] = *v
+		}
+
+		if v := value.Location; v != nil {
+			resource["location"] = *v
+		}
+
+		if err = resp.NextWithContext(ctx); err != nil {
+			return diag.Errorf("error reading resources: %+v", err)
+		}
+
+		tagsFound := 0
+
+		if value.Tags != nil {
+			for requiredTagName, requiredTagValue := range tags {
+				for tagName, tagValue := range value.Tags {
+					if requiredTagName == tagName && requiredTagValue == *tagValue {
+						tagsFound++
+					}
+				}
+			}
+
+			if tagsFound != len(tags) {
+				continue
+			}
+		}
+
+		resources = append(resources, resource)
+	}
+
+	id, _ := uuid.GenerateUUID()
+
+	d.SetId(id)
+
+	d.Set("resources", resources)
+
+	return diags
+}

--- a/azurepreview/data_source_resources_test.go
+++ b/azurepreview/data_source_resources_test.go
@@ -1,0 +1,33 @@
+package azurepreview
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceAzurePreviewResources_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDataSourceAzurePreviewResourcesConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.azurepreview_resources.test", "resources.0.type", "Microsoft.Network/virtualNetworks"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataSourceAzurePreviewResourcesConfigBasic() string {
+	return `
+data "azurepreview_resources" "test" {
+  type = "Microsoft.Network/virtualNetworks"
+  tags = {
+	is_spoke = true
+  }
+}
+`
+}

--- a/azurepreview/provider.go
+++ b/azurepreview/provider.go
@@ -51,7 +51,9 @@ func Provider() *schema.Provider {
 			},
 		},
 
-		DataSourcesMap: map[string]*schema.Resource{},
+		DataSourcesMap: map[string]*schema.Resource{
+			"azurepreview_resources": dataSourceAzurePreviewResources(),
+		},
 
 		ResourcesMap: map[string]*schema.Resource{
 			"azurepreview_subscription": resourceAzurePreviewSubscription(),

--- a/docs/data-sources/azurepreview_resources.md
+++ b/docs/data-sources/azurepreview_resources.md
@@ -1,0 +1,40 @@
+# azurepreview_resources Data Source
+
+Use this data source to get information about Azure resources.
+
+## Example Usage
+
+```hcl
+data "azurepreview_resources" "example" {
+  type = "Microsoft.Network/virtualNetworks"
+  tags = {
+    is_spoke = true
+  }
+}
+```
+
+## Argument Reference
+
+* `subscription_id` - (Optional) The ID of the subscription.
+
+* `name` - (Optional) The name of the resource.
+
+* `resource_group_name` (Optional) The name of the resource group.
+
+* `type` - (Optional) The type of resource. Example: `Microsoft.Network/virtualNetworks`.
+
+* `tags` - (Optional) A mapping of tags used to filter the resources.
+
+## Attribute Reference
+
+* `resources` - One or more `resource` blocks as defined below.
+
+The `resource` block contains:
+
+* `id` - The ID of the resource.
+
+* `name` - The name of the resource.
+
+* `type` - The type of resource.
+
+* `location` - The Azure region where the resource exists.


### PR DESCRIPTION
This adds `azurepreview_resources` data source with `subscription_id` argument, with reference to Teams chat.

**Example Terraform config:**

```hcl
data "azurerm_subscriptions" "main" {
}

data "azurepreview_resources" "main" {
  for_each = {
    for s in data.azurerm_subscriptions.main.subscriptions : 
    s.display_name => s.subscription_id
  }

  type = "Microsoft.Network/virtualNetworks"

  subscription_id = each.value

  tags = {
    is_spoke = true
  }

  provider = azure-preview
}

output "resources" {
  value = data.azurepreview_resources.main
}
```