### PR TITLE
fix(subscription): fix azurerm subscription id in update method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2-beta
+    - uses: actions/setup-go@v2.1.3
       with:
         go-version: '~1.14'
     - run: go test -v ./...

--- a/azurepreview/resource_subscription.go
+++ b/azurepreview/resource_subscription.go
@@ -148,12 +148,17 @@ func resourceAzurePreviewSubscriptionUpdate(ctx context.Context, d *schema.Resou
 
 	client := meta.(*Meta).Subscription
 
+	subscriptionID, err := parseSubscriptionID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	subscriptionName := subscription.Name{
 		SubscriptionName: to.StringPtr(d.Get("name").(string)),
 	}
 
 	if d.HasChange("name") {
-		_, err := client.Rename(ctx, d.Id(), subscriptionName)
+		_, err := client.Rename(ctx, subscriptionID, subscriptionName)
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
Currently, the rename update method fails due to the subscription id being `/subscriptions/{id}`, this change implements the parsing of the string found in the read and delete methods.